### PR TITLE
FIX: Increment CXX version to 14

### DIFF
--- a/adaptive_gridsampler/setup.py
+++ b/adaptive_gridsampler/setup.py
@@ -4,7 +4,7 @@ import torch
 from setuptools import setup
 from torch.utils.cpp_extension import BuildExtension, CUDAExtension
 
-cxx_args = ['-std=c++11']
+cxx_args = ['-std=c++14']
 
 nvcc_args = [
     '-gencode', 'arch=compute_60,code=sm_60',


### PR DESCRIPTION
Recent PyTorch installs require CXX argument to be 14 to compile.